### PR TITLE
ci: install dev extras so pytest is available

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Install deps
         run: |
           python -m pip install --upgrade pip
-          pip install -e .
+          pip install -e '.[dev]'
 
       - name: Run tests
         working-directory: ${{ github.workspace }}


### PR DESCRIPTION
Fixes `pytest: command not found` in CI test job by installing the `[dev]` extras.