### PR TITLE
test+chore: bare-month coverage, dep cleanup, gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ __pycache__/
 .env
 .pytest_cache/
 *.egg-info/
+.maqa/
+runs/
+constitution/
+speckit/

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 *.pyc
 .env
 .pytest_cache/
+*.egg-info/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,5 +35,6 @@ markers = [
 
 [dependency-groups]
 dev = [
+    "pytest>=9.0.3",
     "ruff>=0.15.10",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,12 +16,6 @@ dependencies = [
     "pyyaml>=6.0.3",
 ]
 
-[project.optional-dependencies]
-dev = [
-    "pytest>=8.0.0",
-    "pytest-asyncio>=0.23",
-]
-
 [tool.setuptools.packages.find]
 where = ["src"]
 
@@ -36,5 +30,6 @@ markers = [
 [dependency-groups]
 dev = [
     "pytest>=9.0.3",
+    "pytest-asyncio>=0.23",
     "ruff>=0.15.10",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,13 @@ dependencies = [
     "pyyaml>=6.0.3",
 ]
 
+[project.optional-dependencies]
+dev = [
+    "pytest>=9.0.3",
+    "pytest-asyncio>=0.23",
+    "ruff>=0.15.10",
+]
+
 [tool.setuptools.packages.find]
 where = ["src"]
 

--- a/tests/test_period_detection.py
+++ b/tests/test_period_detection.py
@@ -1,6 +1,25 @@
+import sys
 from datetime import date, timedelta
 
+import pytest
+
 from swarm_powerbi_bot.services.sql_client import extract_date_params, has_period_hint
+
+_FROZEN_TODAY = date(2026, 4, 17)
+
+
+class _FixedDateClass(date):
+    @classmethod
+    def today(cls):
+        return _FROZEN_TODAY
+
+
+@pytest.fixture(autouse=True)
+def _FixedDate(monkeypatch):
+    import swarm_powerbi_bot.services.sql_client as _sql_mod
+
+    monkeypatch.setattr(_sql_mod, "date", _FixedDateClass)
+    monkeypatch.setattr(sys.modules[__name__], "date", _FixedDateClass)
 
 
 def test_has_period_hint_with_week():
@@ -87,3 +106,18 @@ def test_extract_default_30_days():
     today = date.today()
     assert params["DateFrom"] == today - timedelta(days=30)
     assert params["DateTo"] == today
+
+
+@pytest.mark.parametrize(
+    "query, exp_year, exp_month, exp_day_from, exp_day_to",
+    [
+        ("с 1 по 15 марта", 2026, 3, 1, 15),
+        ("с 1 по 15 мая", 2026, 5, 1, 15),
+        ("с 10 по 20 декабря", 2026, 12, 10, 20),
+    ],
+    ids=["march_no_year", "may_no_year", "december_no_year"],
+)
+def test_regression_range(query, exp_year, exp_month, exp_day_from, exp_day_to):
+    params = extract_date_params(query)
+    assert params["DateFrom"] == date(exp_year, exp_month, exp_day_from)
+    assert params["DateTo"] == date(exp_year, exp_month, exp_day_to)

--- a/uv.lock
+++ b/uv.lock
@@ -923,15 +923,10 @@ dependencies = [
     { name = "selenium" },
 ]
 
-[package.optional-dependencies]
-dev = [
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-]
-
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "ruff" },
 ]
 
@@ -940,18 +935,16 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "matplotlib", specifier = ">=3.8.0" },
     { name = "pyodbc", specifier = ">=5.1.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "python-telegram-bot", specifier = ">=21.0" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "selenium", specifier = ">=4.22.0" },
 ]
-provides-extras = ["dev"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-asyncio", specifier = ">=0.23" },
     { name = "ruff", specifier = ">=0.15.10" },
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -931,6 +931,7 @@ dev = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pytest" },
     { name = "ruff" },
 ]
 
@@ -949,7 +950,10 @@ requires-dist = [
 provides-extras = ["dev"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "ruff", specifier = ">=0.15.10" }]
+dev = [
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "ruff", specifier = ">=0.15.10" },
+]
 
 [[package]]
 name = "trio"


### PR DESCRIPTION
Adds bare-month period extraction tests, consolidates dev deps into [dependency-groups], keeps [project.optional-dependencies].dev for pip-based CI, and ignores *.egg-info/.